### PR TITLE
Experiment using withFooPage(cb) to scope particular pages.

### DIFF
--- a/lib/pageFactory.ts
+++ b/lib/pageFactory.ts
@@ -1,0 +1,43 @@
+import { Page } from "@playwright/test";
+import { LoginPage } from "./pages/login.page";
+import { HomePage } from "./pages/home.page";
+import { CreateLinkPage } from "./pages/links/createLink.page";
+import { LinkDetailsPage } from "./pages/links/details.page";
+import { LinksPage } from "./pages/links/links.page";
+
+export interface PageFactory {
+  withLoginPage(cb: (page: LoginPage) => Promise<void>): Promise<void>;
+  withHomePage(cb: (page: HomePage) => Promise<void>): Promise<void>;
+  withCreateLinkPage(cb: (page: CreateLinkPage) => Promise<void>): Promise<void>;
+  withLinkDetailsPage(cb: (page: LinkDetailsPage) => Promise<void>): Promise<void>;
+  withLinksPage(cb: (page: LinksPage) => Promise<void>): Promise<void>;
+}
+
+export function createPageFactory(page: Page): PageFactory {
+  return {
+    async withLoginPage(cb) {
+      const p = new LoginPage(page);
+      await cb(p);
+    },
+
+    async withHomePage(cb) {
+      const p = new HomePage(page);
+      await cb(p);
+    },
+
+    async withCreateLinkPage(cb) {
+      const p = new CreateLinkPage(page);
+      await cb(p);
+    },
+
+    async withLinkDetailsPage(cb) {
+      const p = new LinkDetailsPage(page);
+      await cb(p);
+    },
+
+    async withLinksPage(cb) {
+      const p = new LinksPage(page);
+      await cb(p);
+    },
+  };
+}

--- a/lib/pages.ts
+++ b/lib/pages.ts
@@ -5,6 +5,7 @@ export * from "./pages/home.page";
 export * from "./pages/links/links.page";
 export * from "./pages/links/createLink.page";
 export * from "./pages/links/details.page";
+export * from "./pageFactory";
 
 export type TestOptions = {
   apiURL: string;

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,15 +1,21 @@
 import { test as setup, expect } from "@playwright/test";
-import { LoginPage, HomePage } from "@pages";
+import { createPageFactory, PageFactory } from "@pages";
 
 const authFile = ".auth/user.json";
 
-setup("authenticate", async ({ page }) => {
-  const loginPage = new LoginPage(page);
-  await loginPage.goto();
-  await loginPage.loginWithValidCredentials();
+let $p: PageFactory; // TODO: Inject via fixture?
 
-  const homePage = new HomePage(page);
-  expect(await homePage.navLink.innerText()).toContain("Links");
+setup("authenticate", async ({ page }) => {
+  $p = createPageFactory(page);
+
+  await $p.withLoginPage(async (p) => {
+    await p.goto();
+    await p.loginWithValidCredentials();
+  });
+
+  await $p.withHomePage(async (p) => {
+    expect(await p.navLink.innerText()).toContain("Links");
+  });
 
   await page.context().storageState({ path: authFile });
 });

--- a/tests/ui/login.spec.ts
+++ b/tests/ui/login.spec.ts
@@ -1,31 +1,37 @@
 import { test, expect } from "@playwright/test";
-import { LoginPage, HomePage } from "@pages";
+import { createPageFactory, PageFactory } from "@pages";
 import { faker } from "@helpers";
 
 test.describe("User logs in to Bitly", async () => {
+  let $p: PageFactory; // TODO: Inject via fixture?
+
   test.beforeEach(async ({ page }) => {
     await page.context().clearCookies();
+    $p = createPageFactory(page);
   });
 
-  test("using invalid credentials ", async ({ page }) => {
+  test("using invalid credentials ", async () => {
     const email = faker.internet.email();
 
-    const loginPage = new LoginPage(page);
-    await loginPage.goto();
-    await loginPage.login(email, "INVALID_PASSWORD");
+    await $p.withLoginPage(async (p) => {
+      await p.goto();
+      await p.login(email, "INVALID_PASSWORD");
 
-    await expect(loginPage.invalidCredentialsError).toBeVisible();
+      await expect(p.invalidCredentialsError).toBeVisible();
+    });
   });
 
-  test("using valid credentials", async ({ page }) => {
+  test("using valid credentials", async () => {
     const email: string = process.env.USER_EMAIL ?? "";
     const password: string = process.env.USER_PASSWORD ?? "";
 
-    const loginPage = new LoginPage(page);
-    await loginPage.goto();
-    await loginPage.login(email, password);
+    await $p.withLoginPage(async (p) => {
+      await p.goto();
+      await p.login(email, password);
+    });
 
-    const homePage = new HomePage(page);
-    expect(await homePage.navLink.innerText()).toContain("Links");
+    await $p.withHomePage(async (p) => {
+      expect(await p.navLink.innerText()).toContain("Links");
+    });
   });
 });


### PR DESCRIPTION
Recently saw this pattern out in the wild and decided to adopt it in this PR to see how it feels. 

Using the `withXxxPage(cb)` pattern creates a visual block which can help the maintainer more clearly see the scopes of particular pages. It's sort of like `#tap do { |p| ... }` in Ruby.